### PR TITLE
Add compatibility for Rails 2.3

### DIFF
--- a/jbuilder.gemspec
+++ b/jbuilder.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'activesupport', '>= 3.0.0', '< 5'
+  s.add_dependency 'activesupport', '>= 2.3.0', '< 5'
   s.add_dependency 'multi_json',    '~> 1.2'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -1,5 +1,5 @@
 require 'jbuilder/jbuilder'
-require 'action_dispatch/http/mime_type'
+require 'action_controller/mime_type'
 require 'active_support/cache'
 
 class JbuilderTemplate < Jbuilder

--- a/lib/jbuilder/jbuilder_template.rb
+++ b/lib/jbuilder/jbuilder_template.rb
@@ -1,5 +1,9 @@
 require 'jbuilder/jbuilder'
-require 'action_controller/mime_type'
+begin
+  require 'action_dispatch/http/mime_type'
+rescue LoadError
+  require 'action_controller/mime_type'
+end
 require 'active_support/cache'
 
 class JbuilderTemplate < Jbuilder


### PR DESCRIPTION
Adds jbuilder compatibility for Rails 2.3. This is branched of of jbuilder `v2.2.2`, as this is the last version that doesn't have critical components in its railtie. This version has all the functionality I think we'll need, so I don't think the extra work to get anything newer is worth it at this point.